### PR TITLE
Refactor to MirageJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## 1.0.0 - In-Progress
 * New plugin module created.
+* Refactor from `bigtest/mirage` to `miragejs`

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "devDependencies": {
     "@bigtest/interactor": "^0.9.1",
-    "@bigtest/mirage": "^0.0.1",
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.2.0",
@@ -25,6 +24,9 @@
     "chai-spies": "^1.0.0",
     "core-js": "^3.6.1",
     "eslint": "^6.2.1",
+    "faker": "^4.1.0",
+    "inflected": "^2.0.4",
+    "miragejs": "^0.1.40",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
     "react-intl": "^4.5.1",

--- a/test/helpers/helpers.js
+++ b/test/helpers/helpers.js
@@ -12,7 +12,10 @@ export default function setupApplication({
   hasAllPerms = true,
 } = {}) {
   setupStripesCore({
-    mirageOptions,
+    mirageOptions: {
+      serverType: 'miragejs',
+      ...mirageOptions
+    },
     scenarios,
     stripesConfig: { hasAllPerms },
 

--- a/test/network/factories/eresource.js
+++ b/test/network/factories/eresource.js
@@ -1,4 +1,5 @@
-import { Factory, faker } from '@bigtest/mirage';
+import { Factory } from 'miragejs';
+import faker from 'faker';
 
 export default Factory.extend({
   id: () => faker.random.uuid(),

--- a/test/network/index.js
+++ b/test/network/index.js
@@ -1,4 +1,4 @@
-import { camelize } from '@bigtest/mirage';
+import { camelize, underscore } from 'inflected';
 
 // auto-import all mirage submodules
 const req = require.context('./', true, /\.js$/);
@@ -8,7 +8,7 @@ const modules = req.keys().reduce((acc, modulePath) => {
   const moduleName = moduleParts[2];
 
   if (moduleName) {
-    const moduleKey = camelize(moduleName.replace('.js', ''));
+    const moduleKey = camelize(underscore(moduleName.replace('.js', '')), false);
 
     return Object.assign(acc, {
       [moduleType]: {

--- a/test/network/models/eresource.js
+++ b/test/network/models/eresource.js
@@ -1,3 +1,3 @@
-import { Model } from '@bigtest/mirage';
+import { Model } from 'miragejs';
 
 export default Model.extend();

--- a/test/network/serializers/application.js
+++ b/test/network/serializers/application.js
@@ -1,3 +1,3 @@
-import { RestSerializer } from '@bigtest/mirage';
+import { RestSerializer } from 'miragejs';
 
 export default RestSerializer;

--- a/test/tests/findEresource-test.js
+++ b/test/tests/findEresource-test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import chai from 'chai';
-import { faker } from '@bigtest/mirage';
+import faker from 'faker';
 import spies from 'chai-spies';
 
 import setupApplication, { mount } from '../helpers/helpers';


### PR DESCRIPTION
## Motivation
![Screen Shot 2020-07-14 at 4 57 15 PM](https://user-images.githubusercontent.com/29791650/87475647-25324e00-c5f3-11ea-91b6-6d53fdfacdf4.png)
This is part of an on-going initiative to completely migrate all of `folio-org` projects from `@bigtest/mirage` to `miragejs`.

[`@bigtest/mirage`](https://github.com/bigtestjs/mirage/) was originally a prototype to make `mirage` available to any framework, but it has since been archived in favor of [`miragejs`](https://miragejs.com/). The documentation for `miragejs` is not only prodigious for its extensive API docs but also for its tutorials and guides. Furthermore, it receives regular bug-fixes and maintenance releases in thanks to its extremely large and active community.

Previous PR: [@folio-org/ui-plugin-find-user #148](https://github.com/folio-org/ui-plugin-find-user/pull/148)
_Linking the previous pull request so that subsequent ones can be found tagged below._

<details>
<summary>Overview of progress at the time of the creation of this PR (in chronological order):</summary>
<br>
✅ <code>ui-checkin</code>
<br>
✅ <code>ui-checkout</code>
<br>
☑️ <code>ui-circulation</code>
<br>
☑️ <code>ui-calendar</code>
<br>
✅ <code>ui-agreements</code>
<br>
☑️ <code>ui-app-template</code>
<br>
☑️ <code>ui-inventory</code>
<br>
☑️ <code>ui-data-export</code>
<br>
✅ <code>ui-finc-config</code>
<br>
☑️ <code>ui-licenses</code>
<br>
☑️ <code>ui-erm-comparisons</code>
<br>
☑️ <code>ui-myprofile</code>
<br>
☑️ <code>ui-local-kb-admin</code>
<br>
☑️ <code>ui-marccat</code>
<br>
☑️ <code>ui-finc-select</code>
<br>
☑️ <code>ui-erm-usage</code>
<br>
☑️ <code>ui-notes</code>
<br>
☑️ <code>ui-oai-pmh</code>
<br>
☑️ <code>ui-plugin-find-user</code>
<br>
☑️ <code>ui-plugin-find-eresource</code>
</details>

## Approach
- [x] Cloned, installed, and then ran tests to double check that the tests are passing before refactoring.
- [x] Removed `@bigtest/mirage` and added `inflected`, `faker`, and `miragejs`.
- [x] ESlint & ran tests after the refactor to confirm they all pass.
- [x] Update CHANGELOG.