### PR TITLE
Add and document optional boolean `justDisplayModal` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ of the Module Developer's Guide.
 | `renderTrigger` | func: ({ triggerId, onClick, buttonRef }) => {} | Optional render function for the button to open the Eresource search modal. The `onClick` prop should be called when the trigger is clicked (assuming it is a Button). The `buttonRef` ensures that the trigger button is brought back into focus once the lookup modal is closed. | | |
 | `showPackages` | boolean | Optional prop to only display the packages eresources and its necessary filters | | true |
 | `showTitles` | boolean | Optional prop to only display the title eresources and its necessary filters | | true |
+| `justDisplayModal` | boolean | Whether to directly display the eresource-choosing modal instead of the trigger | | false
 
 **Note:** Both `showPackages` and `showTitles` props should not be passed as false. One of them needs to be true if at all both the props are being passed.
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,32 @@ of the Module Developer's Guide.
 | `renderTrigger` | func: ({ triggerId, onClick, buttonRef }) => {} | Optional render function for the button to open the Eresource search modal. The `onClick` prop should be called when the trigger is clicked (assuming it is a Button). The `buttonRef` ensures that the trigger button is brought back into focus once the lookup modal is closed. | | |
 | `showPackages` | boolean | Optional prop to only display the packages eresources and its necessary filters | | true |
 | `showTitles` | boolean | Optional prop to only display the title eresources and its necessary filters | | true |
-| `justDisplayModal` | boolean | Whether to directly display the eresource-choosing modal instead of the trigger | | false
+| `justDisplayModal` | boolean | See **Controlled invocation** below. | | false
+| `onClose` | func: () => {} | See **Controlled invocation** below. | |
 
 **Note:** Both `showPackages` and `showTitles` props should not be passed as false. One of them needs to be true if at all both the props are being passed.
+
+## Controlled invocation
+
+By default, this plugin renders only a trigger, which when activated invokes an overlay containing the e-resource finder. Closing this overlay is handled by the plugin.
+
+Alternatively, if `justDisplayModal` is provided and true, the finder is displayed directly. When invoked in this way, it is the responsibility of the caller to also provide an `onClose` function which will be invoked when the user clicks the close button. Here is one way this approach can be used:
+```
+const [showFinder, setShowFinder] = useState();
+return <>
+  <Button onClick={() => setShowFinder(true)}>Find</Button>
+  {showFinder &&
+    <Pluggable
+      type="find-eresource"
+      justDisplayModal
+      onClose={() => setShowFinder(false)}
+      onEresourceSelected={someFunction}
+    >
+      Find eResource
+    </Pluggable>
+  }
+</>;
+```
 
 ## Additional information
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,16 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import EresourceSearch from './src/EresourceSearch';
+import EresourceSearchModal from './src/Modal';
 
-export default props => <EresourceSearch {...props} />;
+function PluginFindEresource(props) {
+  return (props.justDisplayModal ?
+    <EresourceSearchModal {...props} /> :
+    <EresourceSearch {...props} />);
+}
+
+PluginFindEresource.propTypes = {
+  justDisplayModal: PropTypes.bool,
+};
+
+export default PluginFindEresource;

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import EresourceSearchModal from './src/Modal';
 
 function PluginFindEresource(props) {
   return (props.justDisplayModal ?
-    <EresourceSearchModal {...props} /> :
+    <EresourceSearchModal open {...props} /> :
     <EresourceSearch {...props} />);
 }
 


### PR DESCRIPTION
When supplied and true, the plugin directly renders the modal
eresource-finder instead of rendering a trigger that will invoke it.

(This is necessary when launching the plugin from a dropdown menu,
otherwise the plugin is DOM-contained within that menu, and vanishes
when the dropdown is hidden.)

See UIPER-9.