### PR TITLE
chore: Bumped to stripes-kint-components ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "typescript": "^2.8.0"
   },
   "dependencies": {
-    "@k-int/stripes-kint-components": "^3.0.3",
+    "@k-int/stripes-kint-components": "^4.0.0",
     "dom-helpers": "^3.4.0",
     "lodash": "^4.17.11",
     "query-string": "^7.1.1",

--- a/src/Container.js
+++ b/src/Container.js
@@ -95,7 +95,7 @@ const Container = ({
     ['ERM', 'EResources', eresourcesQueryParams, ERESOURCES_ELECTRONIC_ENDPOINT],
     ({ pageParam = 0 }) => {
       const params = [...eresourcesQueryParams, `offset=${pageParam}`];
-      return ky.get(encodeURI(`${ERESOURCES_ELECTRONIC_ENDPOINT}?${params?.join('&')}`)).json();
+      return ky.get(`${ERESOURCES_ELECTRONIC_ENDPOINT}?${params?.join('&')}`).json();
     }
   );
 


### PR DESCRIPTION
kint-components 4.0.0 introduces a breaking change, encodeURI should no longer be performed on the output of generateKiwtQueryParams unless `encode` is set to false