### PR TITLE
EResource plugin refactor, refs ERM-2916, ERM-2917 and ERM-2918

### DIFF
--- a/src/Container/Container.js
+++ b/src/Container/Container.js
@@ -1,132 +1,54 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import {
+  JointContainer,
+  PackageContainer,
+  TitleContainer
+} from './subContainers';
 
-import { useQuery } from 'react-query';
-
-import { generateKiwtQueryParams, useRefdata } from '@k-int/stripes-kint-components';
-
-import { useOkapiKy } from '@folio/stripes/core';
-import { getRefdataValuesByDesc, useInfiniteFetch } from '@folio/stripes-erm-components';
-
-import View from '../View';
-
-const [
-  CONTENT_TYPE,
-  LIFECYCLE_STATUS,
-  PUB_TYPE,
-  SCOPE,
-  TYPE
-] = [
-  'ContentType.ContentType',
-  'Pkg.LifecycleStatus',
-  'TitleInstance.PublicationType',
-  'Pkg.AvailabilityScope',
-  'TitleInstance.Type',
-];
-
-const RESULT_COUNT_INCREMENT = 100;
-const ERESOURCES_ELECTRONIC_ENDPOINT = 'erm/resource/electronic';
-
+/* This single plugin is going to handle:
+ *   Package/Title,
+ *   Package
+ *   Title
+ * plugin duties. Work out which is which here
+ * and split to 3 separate subContainers
+ */
 const Container = ({
   onSelectRow,
   showPackages = true,
   showTitles = true,
 }) => {
-  const ky = useOkapiKy();
-  const searchField = useRef();
+  if (showPackages && showTitles) {
+    return (
+      <JointContainer
+        onSelectRow={onSelectRow}
+        showPackages={showPackages}
+        showTitles={showTitles}
+      />
+    );
+  }
 
-  useEffect(() => {
-    if (searchField.current) {
-      searchField.current.focus();
-    }
-  }, []); // This isn't particularly great, but in the interests of saving time migrating, it will have to do
+  if (showPackages) {
+    return (
+      <PackageContainer
+        onSelectRow={onSelectRow}
+        showPackages={showPackages}
+        showTitles={showTitles}
+      />
+    );
+  }
 
-  const refdata = useRefdata({
-    desc: [
-      CONTENT_TYPE,
-      LIFECYCLE_STATUS,
-      PUB_TYPE,
-      SCOPE,
-      TYPE
-    ],
-    endpoint: 'erm/refdata'
-  });
-
-  // We only need local session query here, use state
-  const [query, setQuery] = useState({});
-  const querySetter = ({ nsValues }) => {
-    setQuery({ ...query, ...nsValues });
-  };
-  const queryGetter = () => query;
-
-  const eresourcesQueryParams = useMemo(() => (
-    generateKiwtQueryParams({
-      searchKey: 'name,identifiers.identifier.value,alternateResourceNames.name,description',
-      filterConfig: [{
-        name: 'class',
-        values: [
-          { name: 'package', value: 'org.olf.kb.Pkg' },
-          { name: 'nopackage', value: 'org.olf.kb.TitleInstance' },
-        ]
-      }],
-      filterKeys: {
-        contentType: 'contentTypes.contentType.value',
-        remoteKb: 'remoteKb.id',
-        scope: 'availabilityScope.value',
-        status: 'lifecycleStatus.value',
-        tags: 'tags.value',
-        publicationType: 'publicationType.value',
-        type: 'type.value'
-      },
-      perPage: RESULT_COUNT_INCREMENT,
-    }, (query ?? {}))
-  ), [query]);
-
-  const {
-    infiniteQueryObject: {
-      error: eresourcesError,
-      fetchNextPage: fetchNextEresourcesPage,
-      isLoading: areEresourcesLoading,
-      isError: isEresourcesError
-    },
-    results: eresources = [],
-    total: eresourcesCount = 0
-  } = useInfiniteFetch(
-    ['ERM', 'EResources', eresourcesQueryParams, ERESOURCES_ELECTRONIC_ENDPOINT],
-    ({ pageParam = 0 }) => {
-      const params = [...eresourcesQueryParams, `offset=${pageParam}`];
-      return ky.get(`${ERESOURCES_ELECTRONIC_ENDPOINT}?${params?.join('&')}`).json();
-    }
-  );
-
-  const kbsPath = 'erm/kbs';
-  const { data: kbs = [] } = useQuery(
-    ['ERM', 'KnowledgeBases', kbsPath],
-    () => ky.get(kbsPath).json()
-  );
+  if (showTitles) {
+    return (
+      <TitleContainer
+        onSelectRow={onSelectRow}
+        showPackages={showPackages}
+        showTitles={showTitles}
+      />
+    );
+  }
 
   return (
-    <View
-      data={{
-        eresources,
-        sourceValues: kbs,
-        typeValues: getRefdataValuesByDesc(refdata, TYPE),
-      }}
-      onNeedMoreData={(_askAmount, index) => fetchNextEresourcesPage({ pageParam: index })}
-      onSelectRow={onSelectRow}
-      queryGetter={queryGetter}
-      querySetter={querySetter}
-      showPackages={showPackages}
-      showTitles={showTitles}
-      source={{ // Fake source from useQuery return values;
-        totalCount: () => eresourcesCount,
-        loaded: () => !areEresourcesLoading,
-        pending: () => areEresourcesLoading,
-        failure: () => isEresourcesError,
-        failureMessage: () => eresourcesError.message
-      }}
-      syncToLocationSearch={false}
-    />
+    <div>At least one of showTitles or showPackages must be true</div>
   );
 };
 

--- a/src/Container/Container.js
+++ b/src/Container/Container.js
@@ -1,4 +1,22 @@
 import PropTypes from 'prop-types';
+import { useQuery } from 'react-query';
+
+import { useRefdata } from '@k-int/stripes-kint-components';
+
+import { useOkapiKy } from '@folio/stripes/core';
+import { getRefdataValuesByDesc } from '@folio/stripes-erm-components';
+
+import {
+  AVAILABILITY_CONSTRAINT,
+  CONTENT_TYPE,
+  KBS_ENDPOINT,
+  LIFECYCLE_STATUS,
+  PUB_TYPE,
+  REFDATA_ENDPOINT,
+  SCOPE,
+  TYPE
+} from '../constants';
+
 import {
   JointContainer,
   PackageContainer,
@@ -17,10 +35,39 @@ const Container = ({
   showPackages = true,
   showTitles = true,
 }) => {
+  const ky = useOkapiKy();
+
+  const refdata = useRefdata({
+    desc: [
+      AVAILABILITY_CONSTRAINT,
+      CONTENT_TYPE,
+      LIFECYCLE_STATUS,
+      PUB_TYPE,
+      SCOPE,
+      TYPE
+    ],
+    endpoint: REFDATA_ENDPOINT
+  });
+
+  const { data: kbs = [] } = useQuery(
+    ['ERM', 'KnowledgeBases', KBS_ENDPOINT],
+    () => ky.get(KBS_ENDPOINT).json()
+  );
+
+  const sharedData = {
+    availabilityValues: getRefdataValuesByDesc(refdata, AVAILABILITY_CONSTRAINT),
+    contentTypeValues: getRefdataValuesByDesc(refdata, CONTENT_TYPE),
+    scopeValues: getRefdataValuesByDesc(refdata, SCOPE),
+    sourceValues: kbs,
+    statusValues: getRefdataValuesByDesc(refdata, LIFECYCLE_STATUS),
+    typeValues: getRefdataValuesByDesc(refdata, TYPE),
+  };
+
   if (showPackages && showTitles) {
     return (
       <JointContainer
         onSelectRow={onSelectRow}
+        sharedData={sharedData}
         showPackages={showPackages}
         showTitles={showTitles}
       />
@@ -31,6 +78,7 @@ const Container = ({
     return (
       <PackageContainer
         onSelectRow={onSelectRow}
+        sharedData={sharedData}
         showPackages={showPackages}
         showTitles={showTitles}
       />
@@ -41,6 +89,7 @@ const Container = ({
     return (
       <TitleContainer
         onSelectRow={onSelectRow}
+        sharedData={sharedData}
         showPackages={showPackages}
         showTitles={showTitles}
       />

--- a/src/Container/Container.js
+++ b/src/Container/Container.js
@@ -57,6 +57,7 @@ const Container = ({
   const sharedData = {
     availabilityValues: getRefdataValuesByDesc(refdata, AVAILABILITY_CONSTRAINT),
     contentTypeValues: getRefdataValuesByDesc(refdata, CONTENT_TYPE),
+    publicationTypeValues: getRefdataValuesByDesc(refdata, PUB_TYPE),
     scopeValues: getRefdataValuesByDesc(refdata, SCOPE),
     sourceValues: kbs,
     statusValues: getRefdataValuesByDesc(refdata, LIFECYCLE_STATUS),

--- a/src/Container/Container.test.js
+++ b/src/Container/Container.test.js
@@ -1,17 +1,14 @@
-import { React } from 'react';
-
-
 import {
   mockKintComponents,
   mockErmComponents,
   renderWithIntl
 } from '@folio/stripes-erm-testing';
+
 import { MemoryRouter } from 'react-router-dom';
+
 import translationsProperties from '../../test/helpers';
 
 import Container from './Container';
-
-jest.mock('../View', () => () => <div>View</div>);
 
 jest.mock('@k-int/stripes-kint-components', () => ({
   ...jest.requireActual('@k-int/stripes-kint-components'),
@@ -25,26 +22,65 @@ jest.mock('@folio/stripes-erm-components', () => ({
 
 const onSelectRow = jest.fn();
 
+jest.mock('./subContainers/JointContainer', () => () => <div>JointContainer</div>);
+jest.mock('./subContainers/PackageContainer', () => () => <div>PackageContainer</div>);
+jest.mock('./subContainers/TitleContainer', () => () => <div>TitleContainer</div>);
+
 describe('Container', () => {
   let renderComponent;
-  beforeEach(() => {
-    renderComponent = renderWithIntl(
-      <MemoryRouter>
-        <Container
-          onSelectRow={onSelectRow}
-          showPackages
-        />
-      </MemoryRouter>,
-      translationsProperties
-    );
+  describe('Container with showPackage and showTitle', () => {
+    beforeEach(() => {
+      renderComponent = renderWithIntl(
+        <MemoryRouter>
+          <Container
+            onSelectRow={onSelectRow}
+          />
+        </MemoryRouter>,
+        translationsProperties
+      );
+    });
+
+    test('renders the JointContainer component', () => {
+      const { getByText } = renderComponent;
+      expect(getByText('JointContainer')).toBeInTheDocument();
+    });
   });
 
-  test('renders the View component', () => {
-    const { getByText } = renderComponent;
-    expect(getByText('View')).toBeInTheDocument();
+  describe('Container with showPackage', () => {
+    beforeEach(() => {
+      renderComponent = renderWithIntl(
+        <MemoryRouter>
+          <Container
+            onSelectRow={onSelectRow}
+            showTitles={false}
+          />
+        </MemoryRouter>,
+        translationsProperties
+      );
+    });
+
+    test('renders the PackageContainer component', () => {
+      const { getByText } = renderComponent;
+      expect(getByText('PackageContainer')).toBeInTheDocument();
+    });
   });
 
-  test('should handle onSelectRow', () => {
-    expect(onSelectRow).not.toHaveBeenCalled();
+  describe('Container with showTitle', () => {
+    beforeEach(() => {
+      renderComponent = renderWithIntl(
+        <MemoryRouter>
+          <Container
+            onSelectRow={onSelectRow}
+            showPackages={false}
+          />
+        </MemoryRouter>,
+        translationsProperties
+      );
+    });
+
+    test('renders the TitleContainer component', () => {
+      const { getByText } = renderComponent;
+      expect(getByText('TitleContainer')).toBeInTheDocument();
+    });
   });
 });

--- a/src/Container/subContainers/JointContainer.js
+++ b/src/Container/subContainers/JointContainer.js
@@ -82,15 +82,17 @@ const JointContainer = ({
    * "initialFilterState" or "sortableColumns"
    *
    * Also make use of this for any other props that may change at the view level,
-   * such as the app icon and label
+   * such as the app icon, label and visible columns
    */
+  const iconKey = 'eresource';
   return (
     <View
-      appIcon={<AppIcon app="agreements" iconKey="eresource" />}
+      appIcon={<AppIcon app="agreements" iconKey={iconKey} />}
       data={{
         eresources,
         ...sharedData
       }}
+      iconKey={iconKey}
       initialFilterState={{}}
       initialSearchState={{ query: '' }}
       initialSortState={{ sort: 'name' }}
@@ -115,6 +117,7 @@ const JointContainer = ({
         failureMessage: () => eresourcesError.message
       }}
       syncToLocationSearch={false}
+      visibleColumns={['name', 'type', 'isbn', 'eissn', 'pissn']}
     />
   );
 };

--- a/src/Container/subContainers/JointContainer.js
+++ b/src/Container/subContainers/JointContainer.js
@@ -1,30 +1,22 @@
 /* This Container will handle the use case for combined Package/Title plugin */
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 
-import { useQuery } from 'react-query';
-
-import { generateKiwtQueryParams, useRefdata } from '@k-int/stripes-kint-components';
+import { generateKiwtQueryParams } from '@k-int/stripes-kint-components';
 
 import { AppIcon, useOkapiKy } from '@folio/stripes/core';
-import { getRefdataValuesByDesc, useInfiniteFetch } from '@folio/stripes-erm-components';
+import { useInfiniteFetch } from '@folio/stripes-erm-components';
 
 import View from '../../View';
 import {
-  CONTENT_TYPE,
   ERESOURCES_ELECTRONIC_ENDPOINT,
   FETCH_INCREMENT,
-  KBS_ENDPOINT,
-  LIFECYCLE_STATUS,
-  PUB_TYPE,
-  REFDATA_ENDPOINT,
-  SCOPE,
-  TYPE
 } from '../../constants';
-import { FormattedMessage } from 'react-intl';
 
 const JointContainer = ({
   onSelectRow,
+  sharedData = {},
   showPackages = true,
   showTitles = true,
 }) => {
@@ -36,17 +28,6 @@ const JointContainer = ({
       searchField.current.focus();
     }
   }, []); // This isn't particularly great, but in the interests of saving time migrating, it will have to do
-
-  const refdata = useRefdata({
-    desc: [
-      CONTENT_TYPE,
-      LIFECYCLE_STATUS,
-      PUB_TYPE,
-      SCOPE,
-      TYPE
-    ],
-    endpoint: REFDATA_ENDPOINT
-  });
 
   // We only need local session query here, use state
   const [query, setQuery] = useState({});
@@ -95,11 +76,6 @@ const JointContainer = ({
     }
   );
 
-  const { data: kbs = [] } = useQuery(
-    ['ERM', 'KnowledgeBases', KBS_ENDPOINT],
-    () => ky.get(KBS_ENDPOINT).json()
-  );
-
   /*
    * We are splitting the Joint/Package/Title sections,
    * so any specific SASQ props live at this level now, eg
@@ -113,8 +89,7 @@ const JointContainer = ({
       appIcon={<AppIcon app="agreements" iconKey="eresource" />}
       data={{
         eresources,
-        sourceValues: kbs,
-        typeValues: getRefdataValuesByDesc(refdata, TYPE),
+        ...sharedData
       }}
       initialFilterState={{}}
       initialSearchState={{ query: '' }}
@@ -146,6 +121,7 @@ const JointContainer = ({
 
 JointContainer.propTypes = {
   onSelectRow: PropTypes.func.isRequired,
+  sharedData: PropTypes.object,
   showPackages(props) {
     if (props.showTitles === false && props.showPackages === false) {
       return new Error('Both showTitles and showPackages props cannot be false');

--- a/src/Container/subContainers/JointContainer.js
+++ b/src/Container/subContainers/JointContainer.js
@@ -1,0 +1,159 @@
+/* This Container will handle the use case for combined Package/Title plugin */
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import { useQuery } from 'react-query';
+
+import { generateKiwtQueryParams, useRefdata } from '@k-int/stripes-kint-components';
+
+import { useOkapiKy } from '@folio/stripes/core';
+import { getRefdataValuesByDesc, useInfiniteFetch } from '@folio/stripes-erm-components';
+
+import View from '../../View';
+
+const [
+  CONTENT_TYPE,
+  LIFECYCLE_STATUS,
+  PUB_TYPE,
+  SCOPE,
+  TYPE
+] = [
+  'ContentType.ContentType',
+  'Pkg.LifecycleStatus',
+  'TitleInstance.PublicationType',
+  'Pkg.AvailabilityScope',
+  'TitleInstance.Type',
+];
+
+const RESULT_COUNT_INCREMENT = 25;
+const ERESOURCES_ELECTRONIC_ENDPOINT = 'erm/resource/electronic';
+
+const JointContainer = ({
+  onSelectRow,
+  showPackages = true,
+  showTitles = true,
+}) => {
+  const ky = useOkapiKy();
+  const searchField = useRef();
+
+  useEffect(() => {
+    if (searchField.current) {
+      searchField.current.focus();
+    }
+  }, []); // This isn't particularly great, but in the interests of saving time migrating, it will have to do
+
+  const refdata = useRefdata({
+    desc: [
+      CONTENT_TYPE,
+      LIFECYCLE_STATUS,
+      PUB_TYPE,
+      SCOPE,
+      TYPE
+    ],
+    endpoint: 'erm/refdata'
+  });
+
+  // We only need local session query here, use state
+  const [query, setQuery] = useState({});
+  const querySetter = ({ nsValues }) => {
+    setQuery({ ...query, ...nsValues });
+  };
+  const queryGetter = () => query;
+
+  const eresourcesQueryParams = useMemo(() => (
+    generateKiwtQueryParams({
+      searchKey: 'name,identifiers.identifier.value,alternateResourceNames.name,description',
+      filterConfig: [{
+        name: 'class',
+        values: [
+          { name: 'package', value: 'org.olf.kb.Pkg' },
+          { name: 'nopackage', value: 'org.olf.kb.TitleInstance' },
+        ]
+      }],
+      filterKeys: {
+        contentType: 'contentTypes.contentType.value',
+        remoteKb: 'remoteKb.id',
+        scope: 'availabilityScope.value',
+        status: 'lifecycleStatus.value',
+        tags: 'tags.value',
+        publicationType: 'publicationType.value',
+        type: 'type.value'
+      },
+      perPage: RESULT_COUNT_INCREMENT,
+    }, (query ?? {}))
+  ), [query]);
+
+  const {
+    infiniteQueryObject: {
+      error: eresourcesError,
+      fetchNextPage: fetchNextEresourcesPage,
+      isLoading: areEresourcesLoading,
+      isError: isEresourcesError
+    },
+    results: eresources = [],
+    total: eresourcesCount = 0
+  } = useInfiniteFetch(
+    ['ERM', 'EResources', eresourcesQueryParams, ERESOURCES_ELECTRONIC_ENDPOINT],
+    ({ pageParam = 0 }) => {
+      const params = [...eresourcesQueryParams, `offset=${pageParam}`];
+      return ky.get(`${ERESOURCES_ELECTRONIC_ENDPOINT}?${params?.join('&')}`).json();
+    }
+  );
+
+  const kbsPath = 'erm/kbs';
+  const { data: kbs = [] } = useQuery(
+    ['ERM', 'KnowledgeBases', kbsPath],
+    () => ky.get(kbsPath).json()
+  );
+
+
+  /*
+   * We are splitting the Joint/Package/Title sections,
+   * so any specific SASQ props live at this level now
+   */
+  const sortableColumns = ['name', 'type'];
+  const initialFilterState = {};
+  const initialSearchState = { query: '' };
+  const initialSortState = { sort: 'name' };
+
+  return (
+    <View
+      data={{
+        eresources,
+        sourceValues: kbs,
+        typeValues: getRefdataValuesByDesc(refdata, TYPE),
+      }}
+      initialFilterState={initialFilterState}
+      initialSearchState={initialSearchState}
+      initialSortState={initialSortState}
+      onNeedMoreData={(_askAmount, index) => fetchNextEresourcesPage({ pageParam: index })}
+      onSelectRow={onSelectRow}
+      queryGetter={queryGetter}
+      querySetter={querySetter}
+      showPackages={showPackages}
+      showTitles={showTitles}
+      sortableColumns={sortableColumns}
+      source={{ // Fake source from useQuery return values;
+        totalCount: () => eresourcesCount,
+        loaded: () => !areEresourcesLoading,
+        pending: () => areEresourcesLoading,
+        failure: () => isEresourcesError,
+        failureMessage: () => eresourcesError.message
+      }}
+      syncToLocationSearch={false}
+    />
+  );
+};
+
+JointContainer.propTypes = {
+  onSelectRow: PropTypes.func.isRequired,
+  showPackages(props) {
+    if (props.showTitles === false && props.showPackages === false) {
+      return new Error('Both showTitles and showPackages props cannot be false');
+    }
+    return null;
+  },
+  showTitles: PropTypes.bool,
+};
+
+export default JointContainer;

--- a/src/Container/subContainers/JointContainer.js
+++ b/src/Container/subContainers/JointContainer.js
@@ -6,7 +6,7 @@ import { useQuery } from 'react-query';
 
 import { generateKiwtQueryParams, useRefdata } from '@k-int/stripes-kint-components';
 
-import { useOkapiKy } from '@folio/stripes/core';
+import { AppIcon, useOkapiKy } from '@folio/stripes/core';
 import { getRefdataValuesByDesc, useInfiniteFetch } from '@folio/stripes-erm-components';
 
 import View from '../../View';
@@ -21,6 +21,7 @@ import {
   SCOPE,
   TYPE
 } from '../../constants';
+import { FormattedMessage } from 'react-intl';
 
 const JointContainer = ({
   onSelectRow,
@@ -103,9 +104,13 @@ const JointContainer = ({
    * We are splitting the Joint/Package/Title sections,
    * so any specific SASQ props live at this level now, eg
    * "initialFilterState" or "sortableColumns"
+   *
+   * Also make use of this for any other props that may change at the view level,
+   * such as the app icon and label
    */
   return (
     <View
+      appIcon={<AppIcon app="agreements" iconKey="eresource" />}
       data={{
         eresources,
         sourceValues: kbs,
@@ -116,6 +121,7 @@ const JointContainer = ({
       initialSortState={{ sort: 'name' }}
       onNeedMoreData={(_askAmount, index) => fetchNextEresourcesPage({ pageParam: index })}
       onSelectRow={onSelectRow}
+      paneTitle={<FormattedMessage id="ui-plugin-find-eresource.eresources" />}
       queryGetter={queryGetter}
       querySetter={querySetter}
       /*

--- a/src/Container/subContainers/JointContainer.test.js
+++ b/src/Container/subContainers/JointContainer.test.js
@@ -1,0 +1,47 @@
+import {
+  mockKintComponents,
+  mockErmComponents,
+  renderWithIntl
+} from '@folio/stripes-erm-testing';
+import { MemoryRouter } from 'react-router-dom';
+import translationsProperties from '../../../test/helpers';
+
+import Container from './JointContainer';
+
+jest.mock('../../View', () => () => <div>View</div>);
+
+jest.mock('@k-int/stripes-kint-components', () => ({
+  ...jest.requireActual('@k-int/stripes-kint-components'),
+  ...mockKintComponents
+}));
+
+jest.mock('@folio/stripes-erm-components', () => ({
+  ...jest.requireActual('@folio/stripes-erm-components'),
+  ...mockErmComponents
+}));
+
+const onSelectRow = jest.fn();
+
+describe('JointContainer', () => {
+  let renderComponent;
+  beforeEach(() => {
+    renderComponent = renderWithIntl(
+      <MemoryRouter>
+        <Container
+          onSelectRow={onSelectRow}
+          showPackages
+        />
+      </MemoryRouter>,
+      translationsProperties
+    );
+  });
+
+  test('renders the View component', () => {
+    const { getByText } = renderComponent;
+    expect(getByText('View')).toBeInTheDocument();
+  });
+
+  test('should handle onSelectRow', () => {
+    expect(onSelectRow).not.toHaveBeenCalled();
+  });
+});

--- a/src/Container/subContainers/PackageContainer.js
+++ b/src/Container/subContainers/PackageContainer.js
@@ -6,7 +6,7 @@ import { useQuery } from 'react-query';
 
 import { generateKiwtQueryParams, useRefdata } from '@k-int/stripes-kint-components';
 
-import { useOkapiKy } from '@folio/stripes/core';
+import { AppIcon, useOkapiKy } from '@folio/stripes/core';
 import { getRefdataValuesByDesc, useInfiniteFetch } from '@folio/stripes-erm-components';
 
 import View from '../../View';
@@ -21,6 +21,7 @@ import {
   SCOPE,
   TYPE
 } from '../../constants';
+import { FormattedMessage } from 'react-intl';
 
 const PackageContainer = ({
   onSelectRow,
@@ -96,9 +97,13 @@ const PackageContainer = ({
    * We are splitting the Joint/Package/Title sections,
    * so any specific SASQ props live at this level now, eg
    * "initialFilterState" or "sortableColumns"
+   *
+   * Also make use of this for any other props that may change at the view level,
+   * such as the app icon and label
    */
   return (
     <View
+      appIcon={<AppIcon app="agreements" iconKey="package" />}
       data={{
         eresources,
         sourceValues: kbs,
@@ -109,6 +114,7 @@ const PackageContainer = ({
       initialSortState={{ sort: 'name' }}
       onNeedMoreData={(_askAmount, index) => fetchNextEresourcesPage({ pageParam: index })}
       onSelectRow={onSelectRow}
+      paneTitle={<FormattedMessage id="ui-plugin-find-eresource.packages" />}
       queryGetter={queryGetter}
       querySetter={querySetter}
       /*

--- a/src/Container/subContainers/PackageContainer.js
+++ b/src/Container/subContainers/PackageContainer.js
@@ -75,15 +75,18 @@ const PackageContainer = ({
    * "initialFilterState" or "sortableColumns"
    *
    * Also make use of this for any other props that may change at the view level,
-   * such as the app icon and label
+   * such as the app icon, label and visible columns
    */
+
+  const iconKey = 'package';
   return (
     <View
-      appIcon={<AppIcon app="agreements" iconKey="package" />}
+      appIcon={<AppIcon app="agreements" iconKey={iconKey} />}
       data={{
         eresources,
         ...sharedData
       }}
+      iconKey={iconKey}
       initialFilterState={{}}
       initialSearchState={{ query: '' }}
       initialSortState={{ sort: 'name' }}
@@ -108,6 +111,7 @@ const PackageContainer = ({
         failureMessage: () => eresourcesError.message
       }}
       syncToLocationSearch={false}
+      visibleColumns={['name', 'source', 'status']}
     />
   );
 };

--- a/src/Container/subContainers/PackageContainer.js
+++ b/src/Container/subContainers/PackageContainer.js
@@ -1,6 +1,145 @@
 /* This Container will handle the use case for Package plugin */
-const PackageContainer = () => {
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
 
+import { useQuery } from 'react-query';
+
+import { generateKiwtQueryParams, useRefdata } from '@k-int/stripes-kint-components';
+
+import { useOkapiKy } from '@folio/stripes/core';
+import { getRefdataValuesByDesc, useInfiniteFetch } from '@folio/stripes-erm-components';
+
+import View from '../../View';
+import {
+  CONTENT_TYPE,
+  FETCH_INCREMENT,
+  KBS_ENDPOINT,
+  LIFECYCLE_STATUS,
+  PACKAGES_ENDPOINT,
+  PUB_TYPE,
+  REFDATA_ENDPOINT,
+  SCOPE,
+  TYPE
+} from '../../constants';
+
+const PackageContainer = ({
+  onSelectRow,
+  showPackages = true,
+  showTitles = false,
+}) => {
+  const ky = useOkapiKy();
+  const searchField = useRef();
+
+  useEffect(() => {
+    if (searchField.current) {
+      searchField.current.focus();
+    }
+  }, []); // This isn't particularly great, but in the interests of saving time migrating, it will have to do
+
+  const refdata = useRefdata({
+    desc: [
+      CONTENT_TYPE,
+      LIFECYCLE_STATUS,
+      PUB_TYPE,
+      SCOPE,
+      TYPE
+    ],
+    endpoint: REFDATA_ENDPOINT
+  });
+
+  // We only need local session query here, use state
+  const [query, setQuery] = useState({});
+  const querySetter = ({ nsValues }) => {
+    setQuery({ ...query, ...nsValues });
+  };
+  const queryGetter = () => query;
+
+  const eresourcesQueryParams = useMemo(() => (
+    generateKiwtQueryParams({
+      searchKey: 'name,identifiers.identifier.value,alternateResourceNames.name,description',
+      filterKeys: {
+        contentType: 'contentTypes.contentType.value',
+        remoteKb: 'remoteKb.id',
+        scope: 'availabilityScope.value',
+        status: 'lifecycleStatus.value',
+        tags: 'tags.value',
+        publicationType: 'publicationType.value',
+        type: 'type.value'
+      },
+      perPage: FETCH_INCREMENT,
+    }, (query ?? {}))
+  ), [query]);
+
+  const {
+    infiniteQueryObject: {
+      error: eresourcesError,
+      fetchNextPage: fetchNextEresourcesPage,
+      isLoading: areEresourcesLoading,
+      isError: isEresourcesError
+    },
+    results: eresources = [],
+    total: eresourcesCount = 0
+  } = useInfiniteFetch(
+    ['ERM', 'Packages', eresourcesQueryParams, PACKAGES_ENDPOINT],
+    ({ pageParam = 0 }) => {
+      const params = [...eresourcesQueryParams, `offset=${pageParam}`];
+      return ky.get(`${PACKAGES_ENDPOINT}?${params?.join('&')}`).json();
+    }
+  );
+
+  const { data: kbs = [] } = useQuery(
+    ['ERM', 'KnowledgeBases', KBS_ENDPOINT],
+    () => ky.get(KBS_ENDPOINT).json()
+  );
+
+  /*
+   * We are splitting the Joint/Package/Title sections,
+   * so any specific SASQ props live at this level now, eg
+   * "initialFilterState" or "sortableColumns"
+   */
+  return (
+    <View
+      data={{
+        eresources,
+        sourceValues: kbs,
+        typeValues: getRefdataValuesByDesc(refdata, TYPE),
+      }}
+      initialFilterState={{}}
+      initialSearchState={{ query: '' }}
+      initialSortState={{ sort: 'name' }}
+      onNeedMoreData={(_askAmount, index) => fetchNextEresourcesPage({ pageParam: index })}
+      onSelectRow={onSelectRow}
+      queryGetter={queryGetter}
+      querySetter={querySetter}
+      /*
+       * Technically we don't need to pass these two props,
+       * since we know what combination led to this Container,
+       * but for consistency we'll leave it for all 3.
+       */
+      showPackages={showPackages}
+      showTitles={showTitles}
+      sortableColumns={['name']}
+      source={{ // Fake source from useQuery return values;
+        totalCount: () => eresourcesCount,
+        loaded: () => !areEresourcesLoading,
+        pending: () => areEresourcesLoading,
+        failure: () => isEresourcesError,
+        failureMessage: () => eresourcesError.message
+      }}
+      syncToLocationSearch={false}
+    />
+  );
+};
+
+PackageContainer.propTypes = {
+  onSelectRow: PropTypes.func.isRequired,
+  showPackages(props) {
+    if (props.showTitles === false && props.showPackages === false) {
+      return new Error('Both showTitles and showPackages props cannot be false');
+    }
+    return null;
+  },
+  showTitles: PropTypes.bool,
 };
 
 export default PackageContainer;

--- a/src/Container/subContainers/PackageContainer.js
+++ b/src/Container/subContainers/PackageContainer.js
@@ -1,30 +1,22 @@
 /* This Container will handle the use case for Package plugin */
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 
-import { useQuery } from 'react-query';
-
-import { generateKiwtQueryParams, useRefdata } from '@k-int/stripes-kint-components';
+import { generateKiwtQueryParams } from '@k-int/stripes-kint-components';
 
 import { AppIcon, useOkapiKy } from '@folio/stripes/core';
-import { getRefdataValuesByDesc, useInfiniteFetch } from '@folio/stripes-erm-components';
+import { useInfiniteFetch } from '@folio/stripes-erm-components';
 
 import View from '../../View';
 import {
-  CONTENT_TYPE,
   FETCH_INCREMENT,
-  KBS_ENDPOINT,
-  LIFECYCLE_STATUS,
   PACKAGES_ENDPOINT,
-  PUB_TYPE,
-  REFDATA_ENDPOINT,
-  SCOPE,
-  TYPE
 } from '../../constants';
-import { FormattedMessage } from 'react-intl';
 
 const PackageContainer = ({
   onSelectRow,
+  sharedData = {},
   showPackages = true,
   showTitles = false,
 }) => {
@@ -36,17 +28,6 @@ const PackageContainer = ({
       searchField.current.focus();
     }
   }, []); // This isn't particularly great, but in the interests of saving time migrating, it will have to do
-
-  const refdata = useRefdata({
-    desc: [
-      CONTENT_TYPE,
-      LIFECYCLE_STATUS,
-      PUB_TYPE,
-      SCOPE,
-      TYPE
-    ],
-    endpoint: REFDATA_ENDPOINT
-  });
 
   // We only need local session query here, use state
   const [query, setQuery] = useState({});
@@ -88,11 +69,6 @@ const PackageContainer = ({
     }
   );
 
-  const { data: kbs = [] } = useQuery(
-    ['ERM', 'KnowledgeBases', KBS_ENDPOINT],
-    () => ky.get(KBS_ENDPOINT).json()
-  );
-
   /*
    * We are splitting the Joint/Package/Title sections,
    * so any specific SASQ props live at this level now, eg
@@ -106,8 +82,7 @@ const PackageContainer = ({
       appIcon={<AppIcon app="agreements" iconKey="package" />}
       data={{
         eresources,
-        sourceValues: kbs,
-        typeValues: getRefdataValuesByDesc(refdata, TYPE),
+        ...sharedData
       }}
       initialFilterState={{}}
       initialSearchState={{ query: '' }}
@@ -139,6 +114,7 @@ const PackageContainer = ({
 
 PackageContainer.propTypes = {
   onSelectRow: PropTypes.func.isRequired,
+  sharedData: PropTypes.object,
   showPackages(props) {
     if (props.showTitles === false && props.showPackages === false) {
       return new Error('Both showTitles and showPackages props cannot be false');

--- a/src/Container/subContainers/PackageContainer.js
+++ b/src/Container/subContainers/PackageContainer.js
@@ -1,0 +1,6 @@
+/* This Container will handle the use case for Package plugin */
+const PackageContainer = () => {
+
+};
+
+export default PackageContainer;

--- a/src/Container/subContainers/PackageContainer.test.js
+++ b/src/Container/subContainers/PackageContainer.test.js
@@ -1,0 +1,47 @@
+import {
+  mockKintComponents,
+  mockErmComponents,
+  renderWithIntl
+} from '@folio/stripes-erm-testing';
+import { MemoryRouter } from 'react-router-dom';
+import translationsProperties from '../../../test/helpers';
+
+import Container from './PackageContainer';
+
+jest.mock('../../View', () => () => <div>View</div>);
+
+jest.mock('@k-int/stripes-kint-components', () => ({
+  ...jest.requireActual('@k-int/stripes-kint-components'),
+  ...mockKintComponents
+}));
+
+jest.mock('@folio/stripes-erm-components', () => ({
+  ...jest.requireActual('@folio/stripes-erm-components'),
+  ...mockErmComponents
+}));
+
+const onSelectRow = jest.fn();
+
+describe('PackageContainer', () => {
+  let renderComponent;
+  beforeEach(() => {
+    renderComponent = renderWithIntl(
+      <MemoryRouter>
+        <Container
+          onSelectRow={onSelectRow}
+          showPackages
+        />
+      </MemoryRouter>,
+      translationsProperties
+    );
+  });
+
+  test('renders the View component', () => {
+    const { getByText } = renderComponent;
+    expect(getByText('View')).toBeInTheDocument();
+  });
+
+  test('should handle onSelectRow', () => {
+    expect(onSelectRow).not.toHaveBeenCalled();
+  });
+});

--- a/src/Container/subContainers/TitleContainer.js
+++ b/src/Container/subContainers/TitleContainer.js
@@ -6,7 +6,7 @@ import { useQuery } from 'react-query';
 
 import { generateKiwtQueryParams, useRefdata } from '@k-int/stripes-kint-components';
 
-import { useOkapiKy } from '@folio/stripes/core';
+import { AppIcon, useOkapiKy } from '@folio/stripes/core';
 import { getRefdataValuesByDesc, useInfiniteFetch } from '@folio/stripes-erm-components';
 
 import View from '../../View';
@@ -21,6 +21,7 @@ import {
   SCOPE,
   TYPE
 } from '../../constants';
+import { FormattedMessage } from 'react-intl';
 
 const TitleContainer = ({
   onSelectRow,
@@ -96,9 +97,13 @@ const TitleContainer = ({
    * We are splitting the Joint/Package/Title sections,
    * so any specific SASQ props live at this level now, eg
    * "initialFilterState" or "sortableColumns"
+   *
+   * Also make use of this for any other props that may change at the view level,
+   * such as the app icon and label
    */
   return (
     <View
+      appIcon={<AppIcon app="agreements" iconKey="title" />}
       data={{
         eresources,
         sourceValues: kbs,
@@ -109,6 +114,7 @@ const TitleContainer = ({
       initialSortState={{ sort: 'name' }}
       onNeedMoreData={(_askAmount, index) => fetchNextEresourcesPage({ pageParam: index })}
       onSelectRow={onSelectRow}
+      paneTitle={<FormattedMessage id="ui-plugin-find-eresource.titles" />}
       queryGetter={queryGetter}
       querySetter={querySetter}
       /*

--- a/src/Container/subContainers/TitleContainer.js
+++ b/src/Container/subContainers/TitleContainer.js
@@ -75,15 +75,17 @@ const TitleContainer = ({
    * "initialFilterState" or "sortableColumns"
    *
    * Also make use of this for any other props that may change at the view level,
-   * such as the app icon and label
+   * such as the app icon, label and visible columns
    */
+  const iconKey = 'title';
   return (
     <View
-      appIcon={<AppIcon app="agreements" iconKey="title" />}
+      appIcon={<AppIcon app="agreements" iconKey={iconKey} />}
       data={{
         eresources,
         ...sharedData
       }}
+      iconKey={iconKey}
       initialFilterState={{}}
       initialSearchState={{ query: '' }}
       initialSortState={{ sort: 'name' }}
@@ -108,6 +110,7 @@ const TitleContainer = ({
         failureMessage: () => eresourcesError.message
       }}
       syncToLocationSearch={false}
+      visibleColumns={['name', 'publicationType', 'isbn', 'eissn', 'pissn']}
     />
   );
 };

--- a/src/Container/subContainers/TitleContainer.js
+++ b/src/Container/subContainers/TitleContainer.js
@@ -1,6 +1,145 @@
 /* This Container will handle the use case for Title plugin */
-const TitleContainer = () => {
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
 
+import { useQuery } from 'react-query';
+
+import { generateKiwtQueryParams, useRefdata } from '@k-int/stripes-kint-components';
+
+import { useOkapiKy } from '@folio/stripes/core';
+import { getRefdataValuesByDesc, useInfiniteFetch } from '@folio/stripes-erm-components';
+
+import View from '../../View';
+import {
+  CONTENT_TYPE,
+  FETCH_INCREMENT,
+  KBS_ENDPOINT,
+  LIFECYCLE_STATUS,
+  TITLES_ENDPOINT,
+  PUB_TYPE,
+  REFDATA_ENDPOINT,
+  SCOPE,
+  TYPE
+} from '../../constants';
+
+const TitleContainer = ({
+  onSelectRow,
+  showPackages = true,
+  showTitles = false,
+}) => {
+  const ky = useOkapiKy();
+  const searchField = useRef();
+
+  useEffect(() => {
+    if (searchField.current) {
+      searchField.current.focus();
+    }
+  }, []); // This isn't particularly great, but in the interests of saving time migrating, it will have to do
+
+  const refdata = useRefdata({
+    desc: [
+      CONTENT_TYPE,
+      LIFECYCLE_STATUS,
+      PUB_TYPE,
+      SCOPE,
+      TYPE
+    ],
+    endpoint: REFDATA_ENDPOINT
+  });
+
+  // We only need local session query here, use state
+  const [query, setQuery] = useState({});
+  const querySetter = ({ nsValues }) => {
+    setQuery({ ...query, ...nsValues });
+  };
+  const queryGetter = () => query;
+
+  const eresourcesQueryParams = useMemo(() => (
+    generateKiwtQueryParams({
+      searchKey: 'name,identifiers.identifier.value,alternateResourceNames.name,description',
+      filterKeys: {
+        contentType: 'contentTypes.contentType.value',
+        remoteKb: 'remoteKb.id',
+        scope: 'availabilityScope.value',
+        status: 'lifecycleStatus.value',
+        tags: 'tags.value',
+        publicationType: 'publicationType.value',
+        type: 'type.value'
+      },
+      perPage: FETCH_INCREMENT,
+    }, (query ?? {}))
+  ), [query]);
+
+  const {
+    infiniteQueryObject: {
+      error: eresourcesError,
+      fetchNextPage: fetchNextEresourcesPage,
+      isLoading: areEresourcesLoading,
+      isError: isEresourcesError
+    },
+    results: eresources = [],
+    total: eresourcesCount = 0
+  } = useInfiniteFetch(
+    ['ERM', 'Titles', eresourcesQueryParams, TITLES_ENDPOINT],
+    ({ pageParam = 0 }) => {
+      const params = [...eresourcesQueryParams, `offset=${pageParam}`];
+      return ky.get(`${TITLES_ENDPOINT}?${params?.join('&')}`).json();
+    }
+  );
+
+  const { data: kbs = [] } = useQuery(
+    ['ERM', 'KnowledgeBases', KBS_ENDPOINT],
+    () => ky.get(KBS_ENDPOINT).json()
+  );
+
+  /*
+   * We are splitting the Joint/Package/Title sections,
+   * so any specific SASQ props live at this level now, eg
+   * "initialFilterState" or "sortableColumns"
+   */
+  return (
+    <View
+      data={{
+        eresources,
+        sourceValues: kbs,
+        typeValues: getRefdataValuesByDesc(refdata, TYPE),
+      }}
+      initialFilterState={{}}
+      initialSearchState={{ query: '' }}
+      initialSortState={{ sort: 'name' }}
+      onNeedMoreData={(_askAmount, index) => fetchNextEresourcesPage({ pageParam: index })}
+      onSelectRow={onSelectRow}
+      queryGetter={queryGetter}
+      querySetter={querySetter}
+      /*
+       * Technically we don't need to pass these two props,
+       * since we know what combination led to this Container,
+       * but for consistency we'll leave it for all 3.
+       */
+      showPackages={showPackages}
+      showTitles={showTitles}
+      sortableColumns={['name']}
+      source={{ // Fake source from useQuery return values;
+        totalCount: () => eresourcesCount,
+        loaded: () => !areEresourcesLoading,
+        pending: () => areEresourcesLoading,
+        failure: () => isEresourcesError,
+        failureMessage: () => eresourcesError.message
+      }}
+      syncToLocationSearch={false}
+    />
+  );
+};
+
+TitleContainer.propTypes = {
+  onSelectRow: PropTypes.func.isRequired,
+  showPackages(props) {
+    if (props.showTitles === false && props.showPackages === false) {
+      return new Error('Both showTitles and showPackages props cannot be false');
+    }
+    return null;
+  },
+  showTitles: PropTypes.bool,
 };
 
 export default TitleContainer;

--- a/src/Container/subContainers/TitleContainer.js
+++ b/src/Container/subContainers/TitleContainer.js
@@ -1,30 +1,22 @@
 /* This Container will handle the use case for Title plugin */
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 
-import { useQuery } from 'react-query';
-
-import { generateKiwtQueryParams, useRefdata } from '@k-int/stripes-kint-components';
+import { generateKiwtQueryParams } from '@k-int/stripes-kint-components';
 
 import { AppIcon, useOkapiKy } from '@folio/stripes/core';
-import { getRefdataValuesByDesc, useInfiniteFetch } from '@folio/stripes-erm-components';
+import { useInfiniteFetch } from '@folio/stripes-erm-components';
 
 import View from '../../View';
 import {
-  CONTENT_TYPE,
   FETCH_INCREMENT,
-  KBS_ENDPOINT,
-  LIFECYCLE_STATUS,
   TITLES_ENDPOINT,
-  PUB_TYPE,
-  REFDATA_ENDPOINT,
-  SCOPE,
-  TYPE
 } from '../../constants';
-import { FormattedMessage } from 'react-intl';
 
 const TitleContainer = ({
   onSelectRow,
+  sharedData = {},
   showPackages = true,
   showTitles = false,
 }) => {
@@ -36,17 +28,6 @@ const TitleContainer = ({
       searchField.current.focus();
     }
   }, []); // This isn't particularly great, but in the interests of saving time migrating, it will have to do
-
-  const refdata = useRefdata({
-    desc: [
-      CONTENT_TYPE,
-      LIFECYCLE_STATUS,
-      PUB_TYPE,
-      SCOPE,
-      TYPE
-    ],
-    endpoint: REFDATA_ENDPOINT
-  });
 
   // We only need local session query here, use state
   const [query, setQuery] = useState({});
@@ -88,11 +69,6 @@ const TitleContainer = ({
     }
   );
 
-  const { data: kbs = [] } = useQuery(
-    ['ERM', 'KnowledgeBases', KBS_ENDPOINT],
-    () => ky.get(KBS_ENDPOINT).json()
-  );
-
   /*
    * We are splitting the Joint/Package/Title sections,
    * so any specific SASQ props live at this level now, eg
@@ -106,8 +82,7 @@ const TitleContainer = ({
       appIcon={<AppIcon app="agreements" iconKey="title" />}
       data={{
         eresources,
-        sourceValues: kbs,
-        typeValues: getRefdataValuesByDesc(refdata, TYPE),
+        ...sharedData
       }}
       initialFilterState={{}}
       initialSearchState={{ query: '' }}
@@ -139,6 +114,7 @@ const TitleContainer = ({
 
 TitleContainer.propTypes = {
   onSelectRow: PropTypes.func.isRequired,
+  sharedData: PropTypes.object,
   showPackages(props) {
     if (props.showTitles === false && props.showPackages === false) {
       return new Error('Both showTitles and showPackages props cannot be false');

--- a/src/Container/subContainers/TitleContainer.js
+++ b/src/Container/subContainers/TitleContainer.js
@@ -1,0 +1,6 @@
+/* This Container will handle the use case for Title plugin */
+const TitleContainer = () => {
+
+};
+
+export default TitleContainer;

--- a/src/Container/subContainers/TitleContainer.test.js
+++ b/src/Container/subContainers/TitleContainer.test.js
@@ -1,0 +1,47 @@
+import {
+  mockKintComponents,
+  mockErmComponents,
+  renderWithIntl
+} from '@folio/stripes-erm-testing';
+import { MemoryRouter } from 'react-router-dom';
+import translationsProperties from '../../../test/helpers';
+
+import Container from './TitleContainer';
+
+jest.mock('../../View', () => () => <div>View</div>);
+
+jest.mock('@k-int/stripes-kint-components', () => ({
+  ...jest.requireActual('@k-int/stripes-kint-components'),
+  ...mockKintComponents
+}));
+
+jest.mock('@folio/stripes-erm-components', () => ({
+  ...jest.requireActual('@folio/stripes-erm-components'),
+  ...mockErmComponents
+}));
+
+const onSelectRow = jest.fn();
+
+describe('TitleContainer', () => {
+  let renderComponent;
+  beforeEach(() => {
+    renderComponent = renderWithIntl(
+      <MemoryRouter>
+        <Container
+          onSelectRow={onSelectRow}
+          showPackages
+        />
+      </MemoryRouter>,
+      translationsProperties
+    );
+  });
+
+  test('renders the View component', () => {
+    const { getByText } = renderComponent;
+    expect(getByText('View')).toBeInTheDocument();
+  });
+
+  test('should handle onSelectRow', () => {
+    expect(onSelectRow).not.toHaveBeenCalled();
+  });
+});

--- a/src/Container/subContainers/index.js
+++ b/src/Container/subContainers/index.js
@@ -1,0 +1,3 @@
+export { default as JointContainer } from './JointContainer';
+export { default as PackageContainer } from './PackageContainer';
+export { default as TitleContainer } from './TitleContainer';

--- a/src/Filters/Filters.js
+++ b/src/Filters/Filters.js
@@ -53,6 +53,7 @@ const Filters = ({
 
     return (
       <Accordion
+        key="render-is-package-filter"
         displayClearButton={groupFilters.length > 0}
         header={FilterAccordionHeader}
         id="filter-accordion-is-package"
@@ -83,6 +84,7 @@ const Filters = ({
 
     return (
       <Accordion
+        key={`render-checkbox-filter-${name}`}
         displayClearButton={groupFilters.length > 0}
         header={FilterAccordionHeader}
         id={`filter-accordion-${name}`}
@@ -115,6 +117,7 @@ const Filters = ({
 
     return (
       <Accordion
+        key="render-remote-kb-filter"
         displayClearButton={remoteKbFilters.length > 0}
         header={FilterAccordionHeader}
         id="filter-accordion-remoteKb"
@@ -137,6 +140,7 @@ const Filters = ({
 
     return (
       <Accordion
+        key="render-availability-filter"
         displayClearButton={availabilityFilters.length > 0}
         header={FilterAccordionHeader}
         id="clickable-availability-filter"

--- a/src/Filters/Filters.js
+++ b/src/Filters/Filters.js
@@ -3,11 +3,12 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
 import { Accordion, AccordionSet, FilterAccordionHeader, Selection } from '@folio/stripes/components';
-import { CheckboxFilter } from '@folio/stripes/smart-components';
+import { CheckboxFilter, MultiSelectionFilter } from '@folio/stripes/smart-components';
 
 const FILTERS = [
   'availability',
   'contentType',
+  'publicationType',
   'scope',
   'status',
   'type'
@@ -26,6 +27,7 @@ const Filters = ({
   const [filterState, setFilterState] = useState({
     availability: [],
     contentType: [],
+    publicationType: [],
     scope: [],
     status: [],
     type: []
@@ -130,11 +132,46 @@ const Filters = ({
     );
   };
 
+  const renderAvailabilityFilter = () => {
+    const availabilityFilters = activeFilters.availability || [];
+
+    return (
+      <Accordion
+        displayClearButton={availabilityFilters.length > 0}
+        header={FilterAccordionHeader}
+        id="clickable-availability-filter"
+        label={<FormattedMessage id="ui-agreements.eresources.availability" />}
+        onClearFilter={() => { filterHandlers.clearGroup('availability'); }}
+        separator={false}
+      >
+        <MultiSelectionFilter
+          dataOptions={filterState.availability || []}
+          id="availability-filter"
+          name="availability"
+          onChange={e => filterHandlers.state({ ...activeFilters, availability: e.values })}
+          selectedValues={availabilityFilters}
+        />
+      </Accordion>
+    );
+  };
+
+  const renderTitleFilters = () => ([
+    renderCheckboxFilter('type')
+  ]);
+
+  const renderPackageFilters = () => ([
+    renderCheckboxFilter('status'),
+    renderCheckboxFilter('scope'),
+    renderAvailabilityFilter(),
+    renderCheckboxFilter('contentType'),
+    renderRemoteKbFilter()
+  ]);
+
   return (
     <AccordionSet>
-      {showTitles && renderCheckboxFilter('type')}
       {showTitles && showPackages && renderIsPackageFilter()}
-      {showPackages && renderRemoteKbFilter()}
+      {showTitles && renderTitleFilters()}
+      {showPackages && renderPackageFilters()}
     </AccordionSet>
   );
 };

--- a/src/Filters/Filters.js
+++ b/src/Filters/Filters.js
@@ -160,7 +160,8 @@ const Filters = ({
   };
 
   const renderTitleFilters = () => ([
-    renderCheckboxFilter('type')
+    renderCheckboxFilter('type'),
+    renderCheckboxFilter('publicationType')
   ]);
 
   const renderPackageFilters = () => ([

--- a/src/Filters/Filters.test.js
+++ b/src/Filters/Filters.test.js
@@ -40,35 +40,53 @@ describe('Filters', () => {
     await Accordion('Type').is({ open: true });
   });
 
-  test('renders Type Checkboxs', async () => {
-    await Checkbox({ id: 'clickable-filter-type-monograph' }).exists();
-    await Checkbox({ id: 'clickable-filter-type-serial' }).exists();
-  });
+  /*
+   * EXAMPLE This helper function will test existence of checkboxes
+   * for each of the values defined in testResources refdata
+   * and also whether they are all clickable.
+   */
+  let index = 1;
+  const testNamedFilterCheckboxes = (name) => {
+    describe(`${name} filter`, () => {
+      const promiseList = [];
+      const valuesList = [];
+      data?.[`${name}Values`]?.forEach((value) => {
+        promiseList.push(Checkbox({ id: `clickable-filter-${name}-${value?.value}` }).exists());
+        valuesList.push(value?.value);
+      });
 
-  test('renders Is package Checkboxs', async () => {
+      test(`renders all ${name} checkboxes`, () => {
+        Promise.all(promiseList);
+      });
+
+      valuesList.forEach((value) => {
+        test(`clicking the ${value} checkbox within the ${name} filter`, async () => {
+          await waitFor(async () => {
+            await Checkbox({ id: `clickable-filter-${name}-${value}` }).click();
+          });
+
+          await waitFor(() => {
+            expect(stateMock.mock.calls.length).toEqual(index);
+          });
+
+          index++;
+        });
+      });
+    });
+  };
+
+  testNamedFilterCheckboxes('type');
+  testNamedFilterCheckboxes('publicationType');
+  testNamedFilterCheckboxes('status');
+  testNamedFilterCheckboxes('scope');
+  testNamedFilterCheckboxes('contentType');
+
+  test('renders IsPackage Checkboxes', async () => {
     await Checkbox({ id: 'clickable-filter-class-package' }).exists();
     await Checkbox({ id: 'clickable-filter-class-nopackage' }).exists();
   });
 
-  let index = 1;
-  const testFilterCheckbox = (field, value) => (
-    test(`clicking the ${value} checkbox`, async () => {
-      await waitFor(async () => {
-        await Checkbox({ id: `clickable-filter-${field}-${value}` }).click();
-      });
-
-      await waitFor(() => {
-        expect(stateMock.mock.calls.length).toEqual(index);
-      });
-
-      index++;
-    })
-  );
-
-  testFilterCheckbox('type', 'monograph');
-  testFilterCheckbox('type', 'serial');
-
-  test('renders the Is package Accordion', async () => {
+  test('renders the IsPackage Accordion', async () => {
     await Accordion('Is package').exists();
   });
 

--- a/src/Filters/testResources.js
+++ b/src/Filters/testResources.js
@@ -5,102 +5,147 @@ const activeFilters = {
 };
 
 const data = {
-  'eresources': [{
-    'id': 'c95b7b8a-8f25-4f9e-946c-d9453abaea14',
-    'class': 'org.olf.kb.TitleInstance',
-    'name': '"Alles ist eins"',
-    'suppressFromDiscovery': false,
-    'tags': '[]',
-    'alternateResourceNames': '[]',
-    'type': '{id: "2c91809c843894050184389bed480004", label: "Mo…}',
-    'publicationType': '{id: "2c91809c843894050184389dbcad006d", label: "Bo…}',
-    'subType': '{id: "2c91809c843894050184389bed3f0002", label: "El…}',
-    'customCoverage': false,
-    '_object': {
-      'id': 'c95b7b8a-8f25-4f9e-946c-d9453abaea14',
-      'subType': {
-        'id': '2c91809c843894050184389bed3f0002',
-        'value': 'electronic',
-        'label': 'Electronic'
-      },
-      'dateCreated': '2022-11-02T16:06:30Z',
-      'tags': [],
-      'lastUpdated': '2022-11-02T16:06:30Z',
-      'normalizedName': '"alles ist eins"',
-      'dateMonographPublished': '2021-02-01',
-      'monographEdition': 'monograph',
-      'publicationType': {
-        'id': '2c91809c843894050184389dbcad006d',
-        'value': 'book',
-        'label': 'Book'
-      },
-      'coverage': [],
-      'alternateResourceNames': [],
-      'name': '"Alles ist eins"',
-      'type': {
-        'id': '2c91809c843894050184389bed480004',
-        'value': 'monograph',
-        'label': 'Monograph'
-      },
-      'suppressFromDiscovery': false,
-      'work': {
-        'id': '23d7c3de-1a92-4bfb-9016-5ee4af137743'
-      },
-      'platformInstances': [{
-        'id': '96a57fbe-9b4e-4bac-9d17-2cd0b3561c4c'
-      }],
-      'firstAuthor': 'Börnchen',
-      'class': 'org.olf.kb.TitleInstance',
-      'longName': '"Alles ist eins".2021-02-01 (monograph)',
-      'identifiers': [{
-        'dateCreated': '2022-11-02T16:06:30Z',
-        'lastUpdated': '2022-11-02T16:06:30Z',
-        'status': {
-          'id': '2c91809c843894050184389c87630064',
-          'value': 'approved',
-          'label': 'approved'
-        },
-        'identifier': {
-          'value': '9783846763698',
-          'ns': {
-            'value': 'isbn'
-          }
-        }
-      }],
-      'relatedTitles': [{
-        'id': '9b704ae0-c84a-4977-b3ad-0c6ea7559c10',
-        'subType': {
-          'id': '2c91809c843894050184389bed300001',
-          'value': 'print',
-          'label': 'Print'
-        },
-        'publicationType': {
-          'id': '2c91809c843894050184389dbcad006d',
-          'value': 'book',
-          'label': 'Book'
-        },
-        'name': '"Alles ist eins"',
-        'type': {
-          'id': '2c91809c843894050184389bed480004',
-          'value': 'monograph',
-          'label': 'Monograph'
-        },
-        'longName': '"Alles ist eins".2021-02-01 (monograph)',
-        'identifiers': [
-          '{dateCreated: "2022-11-02T16:06:30Z", identifier: {…}'
-        ]
-      }]
-    }
+  'availabilityValues': [{
+    'id': '2c9180a687b0eea70187b153765d0080',
+    'value': 'allianzlizenz',
+    'label': 'Allianzlizenz'
+  }, {
+    'id': '2c9180a687b0eea70187b17cfa7d0081',
+    'value': 'diku',
+    'label': 'DIKU'
+  }, {
+    'id': '2c9180a687b0eea70187b152ed39007f',
+    'value': 'gwlb_hannover',
+    'label': 'GWLB Hannover'
+  }, {
+    'id': '2c9180a687b0eea70187b151fee4007e',
+    'value': 'hawk',
+    'label': 'HAWK'
+  }, {
+    'id': '2c9180a687b0eea70187b18267d10083',
+    'value': 'hbz',
+    'label': 'HBZ'
+  }, {
+    'id': '2c9180a687b0eea70187b116cc3b0077',
+    'value': 'hil',
+    'label': 'HIL'
+  }, {
+    'id': '2c9180a687b0eea70187b1a9c29c0085',
+    'value': 'hs_hannover',
+    'label': 'HS Hannover'
+  }, {
+    'id': '2c9180a687b0eea70187b0fd674d0071',
+    'value': 'hebis',
+    'label': 'HeBIS'
+  }, {
+    'id': '2c9180a687b0eea70187b126336c007a',
+    'value': 'hebis-konsortium',
+    'label': 'HeBIS-Konsortium'
+  }, {
+    'id': '2c9180a687b0eea70187b1ac20750086',
+    'value': 'iai_berlin',
+    'label': 'IAI Berlin'
+  }, {
+    'id': '2c9180a687b0eea70187b17f68f30082',
+    'value': 'mlu_halle',
+    'label': 'MLU Halle'
+  }, {
+    'id': '2c9180a687b0eea70187b1513b09007c',
+    'value': 'nationalkonsortium',
+    'label': 'Nationalkonsortium'
+  }, {
+    'id': '2c9180a687b0eea70187b11ff03c0078',
+    'value': 'nationallizenz',
+    'label': 'Nationallizenz'
+  }, {
+    'id': '2c9180a687b0eea70187b1513bd0007d',
+    'value': 'slub_dresden',
+    'label': 'SLUB Dresden'
+  }, {
+    'id': '2c9180a687b0eea70187b191ecee0084',
+    'value': 'smb',
+    'label': 'SMB'
+  }, {
+    'id': '2c9180a687b0eea70187b1ae0ce10087',
+    'value': 'thws',
+    'label': 'THWS'
+  }, {
+    'id': '2c9180a687b0eea70187b12209c10079',
+    'value': 'tib',
+    'label': 'TIB'
+  }, {
+    'id': '2c9180a687b0eea70187b1472d14007b',
+    'value': 'tu_hamburg',
+    'label': 'TU Hamburg'
+  }, {
+    'id': '2c9180a687b0eea70187b10dabfa0075',
+    'value': 'vzg',
+    'label': 'VZG'
+  }, {
+    'id': '2c9180a687b0eea70187b0f60664006d',
+    'value': 'zbw',
+    'label': 'ZBW'
+  }],
+  'contentTypeValues': [{
+    'id': '2c9180a687b0eea70187b0f60302006a',
+    'value': 'book',
+    'label': 'Book'
+  }, {
+    'id': '2c9180a687b0eea70187b10318680072',
+    'value': 'database',
+    'label': 'Database'
+  }, {
+    'id': '2c9180a687b0eea70187b0f5c8000065',
+    'value': 'journal',
+    'label': 'Journal'
+  }, {
+    'id': '2c9180a687b0eea70187b116cb3b0076',
+    'value': 'mixed',
+    'label': 'Mixed'
+  }],
+  'publicationTypeValues': [{
+    'id': '2c9180a687b0eea70187b0f6d2390070',
+    'value': 'book',
+    'label': 'Book'
+  }, {
+    'id': '2c9180a687b0eea70187b10318820073',
+    'value': 'database',
+    'label': 'Database'
+  }, {
+    'id': '2c9180a687b0eea70187b0f5c97c0069',
+    'value': 'journal',
+    'label': 'Journal'
+  }],
+  'scopeValues': [{
+    'id': '2c9180a687b0eea70187b0f6207f006e',
+    'value': 'consortium',
+    'label': 'Consortium'
+  }, {
+    'id': '2c9180a687b0eea70187b0f4fbcc0001',
+    'value': 'global',
+    'label': 'Global'
+  }, {
+    'id': '2c9180a687b0eea70187b0f6064a006b',
+    'value': 'local',
+    'label': 'Local'
+  }, {
+    'id': '2c9180a687b0eea70187b1031b500074',
+    'value': 'other',
+    'label': 'Other'
+  }, {
+    'id': '2c9180a687b0eea70187b0f6c127006f',
+    'value': 'regional',
+    'label': 'Regional'
   }],
   'sourceValues': [{
-    'id': 'a6c320f7-76b8-4db5-abaf-342a7673e997',
-    'cursor': '2022-10-31T05:07:25Z',
+    'id': '4932a3fe-c679-4021-9313-d3bcd5002343',
+    'cursor': '2023-04-24T10:14:02Z',
     'active': true,
     'trustedSourceTI': false,
     'activationEnabled': false,
     'readonly': false,
     'syncStatus': 'idle',
-    'lastCheck': 1667472216858,
+    'lastCheck': 1682343926987,
     'name': 'GOKb_TEST',
     'type': 'org.olf.kb.adapters.GOKbOAIAdapter',
     'fullPrefix': 'gokb',
@@ -108,17 +153,32 @@ const data = {
     'supportsHarvesting': true,
     'rectype': 1
   }],
+  'statusValues': [{
+    'id': '2c9180a687b0eea70187b0f4fbd50003',
+    'value': 'current',
+    'label': 'Current'
+  }, {
+    'id': '2c9180a687b0eea70187b0f4fbf50006',
+    'value': 'deleted',
+    'label': 'Deleted'
+  }, {
+    'id': '2c9180a687b0eea70187b0f4fbee0005',
+    'value': 'expected',
+    'label': 'Expected'
+  }, {
+    'id': '2c9180a687b0eea70187b0f4fbe40004',
+    'value': 'retired',
+    'label': 'Retired'
+  }],
   'typeValues': [{
-    'id': '2c91809c843894050184389bed480004',
+    'id': '2c9180a687b0eea70187b0f4fce7003e',
     'value': 'monograph',
     'label': 'Monograph'
-  },
-  {
-    'id': '2c91809c843894050184389bed4d0005',
+  }, {
+    'id': '2c9180a687b0eea70187b0f4fcec003f',
     'value': 'serial',
     'label': 'Serial'
-  }
-  ]
+  }]
 };
 
 export {

--- a/src/View/View.js
+++ b/src/View/View.js
@@ -34,6 +34,9 @@ const propTypes = {
   data: PropTypes.shape({
     eresources: PropTypes.arrayOf(PropTypes.object).isRequired,
   }),
+  initialFilterState: PropTypes.object,
+  initialSearchState: PropTypes.object,
+  initialSortState: PropTypes.object,
   onNeedMoreData: PropTypes.func.isRequired,
   onSelectRow: PropTypes.func.isRequired,
   queryGetter: PropTypes.func.isRequired,
@@ -41,6 +44,7 @@ const propTypes = {
   selectedRecordId: PropTypes.string,
   showPackages: PropTypes.bool,
   showTitles: PropTypes.bool,
+  sortableColumns: PropTypes.arrayOf(PropTypes.string),
   source: PropTypes.shape({
     loaded: PropTypes.func,
     totalCount: PropTypes.func,
@@ -50,11 +54,15 @@ const propTypes = {
 
 const EResources = ({
   data = {},
+  initialFilterState = {},
+  initialSearchState = { query: '' },
+  initialSortState = { sort: 'name' },
   onNeedMoreData,
   onSelectRow,
   queryGetter,
   querySetter,
   selectedRecordId,
+  sortableColumns = ['name'],
   source,
   showPackages,
   showTitles,
@@ -68,20 +76,13 @@ const EResources = ({
 
   const [filterPaneIsVisible, setFilterPaneIsVisible] = useState(true);
   const toggleFilterPane = () => setFilterPaneIsVisible(!filterPaneIsVisible);
-  let initialFilterState = {};
-  let sortableColumns = ['name', 'type'];
-
-  if (!showPackages) initialFilterState = { class: ['nopackage'] };
-  else if (!showTitles) initialFilterState = { class: ['package'] };
-
-  if (showPackages && !showTitles) sortableColumns = ['name'];
 
   return (
     <div data-test-eresources>
       <SearchAndSortQuery
         initialFilterState={initialFilterState}
-        initialSearchState={{ query: '' }}
-        initialSortState={{ sort: 'name' }}
+        initialSearchState={initialSearchState}
+        initialSortState={initialSortState}
         queryGetter={queryGetter}
         querySetter={querySetter}
         setQueryOnMount

--- a/src/View/View.js
+++ b/src/View/View.js
@@ -12,8 +12,6 @@ import {
   Paneset,
 } from '@folio/stripes/components';
 
-import { AppIcon } from '@folio/stripes/core';
-
 import {
   CollapseFilterPaneButton,
   ExpandFilterPaneButton,
@@ -37,12 +35,14 @@ import css from './View.css';
  * (and all combinations thereof)
  */
 const EResources = ({
+  appIcon,
   data = {},
   initialFilterState = {},
   initialSearchState = { query: '' },
   initialSortState = { sort: 'name' },
   onNeedMoreData,
   onSelectRow,
+  paneTitle,
   queryGetter,
   querySetter,
   selectedRecordId,
@@ -154,7 +154,7 @@ const EResources = ({
                   </Pane>
                 }
                 <Pane
-                  appIcon={<AppIcon app="agreements" iconKey="eresource" />}
+                  appIcon={appIcon}
                   defaultWidth="fill"
                   firstMenu={
                     !filterPaneIsVisible ?
@@ -176,7 +176,7 @@ const EResources = ({
                       <FormattedMessage id="stripes-smart-components.searchResultsCountHeader" values={{ count }} /> :
                       <FormattedMessage id="stripes-smart-components.searchCriteria" />
                   }
-                  paneTitle={<FormattedMessage id="ui-plugin-find-eresource.eresources" />}
+                  paneTitle={paneTitle}
                 >
                   <MultiColumnList
                     autosize
@@ -238,6 +238,7 @@ const EResources = ({
 };
 
 EResources.propTypes = {
+  appIcon: PropTypes.node,
   data: PropTypes.shape({
     eresources: PropTypes.arrayOf(PropTypes.object).isRequired,
   }),
@@ -246,6 +247,7 @@ EResources.propTypes = {
   initialSortState: PropTypes.object,
   onNeedMoreData: PropTypes.func.isRequired,
   onSelectRow: PropTypes.func.isRequired,
+  paneTitle: PropTypes.node,
   queryGetter: PropTypes.func.isRequired,
   querySetter: PropTypes.func.isRequired,
   selectedRecordId: PropTypes.string,

--- a/src/View/View.js
+++ b/src/View/View.js
@@ -2,6 +2,8 @@ import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
+import { AppIcon } from '@folio/stripes/core';
+
 import {
   MultiColumnList,
   SearchField,
@@ -37,6 +39,7 @@ import css from './View.css';
 const EResources = ({
   appIcon,
   data = {},
+  iconKey = 'eresource',
   initialFilterState = {},
   initialSearchState = { query: '' },
   initialSortState = { sort: 'name' },
@@ -50,7 +53,8 @@ const EResources = ({
   source,
   showPackages,
   showTitles,
-  syncToLocationSearch
+  syncToLocationSearch,
+  visibleColumns = ['name', 'type', 'isbn', 'eissn', 'pissn']
 }) => {
   const count = source?.totalCount() ?? 0;
   const query = queryGetter() ?? {};
@@ -186,6 +190,8 @@ const EResources = ({
                       isbn: <FormattedMessage id="ui-plugin-find-eresource.prop.isbn" />,
                       eissn: <FormattedMessage id="ui-plugin-find-eresource.prop.eissn" />,
                       pissn: <FormattedMessage id="ui-plugin-find-eresource.prop.pissn" />,
+                      source: <FormattedMessage id="ui-plugin-find-eresource.prop.source" />,
+                      status: <FormattedMessage id="ui-plugin-find-eresource.prop.status" />,
                     }}
                     columnWidths={{
                       name: 300,
@@ -196,11 +202,24 @@ const EResources = ({
                     }}
                     contentData={data.eresources}
                     formatter={{
-                      name: e => e._object?.longName ?? e.name,
+                      name: e => {
+                        return (
+                          <AppIcon
+                            app="agreements"
+                            iconAlignment="baseline"
+                            iconKey={iconKey}
+                            size="small"
+                          >
+                            {e._object?.longName ?? e.name}
+                          </AppIcon>
+                        );
+                      },
                       type: e => <EResourceType resource={e} />,
                       isbn: e => getResourceIdentifier(e._object, 'isbn'),
                       eissn: e => getResourceIdentifier(e._object, 'eissn'),
                       pissn: e => getResourceIdentifier(e._object, 'pissn') ?? getSiblingIdentifier(e._object, 'issn'),
+                      source: e => (e.source),
+                      status: e => (e.lifecycleStatus?.label),
                     }}
                     id="list-eresources"
                     isEmptyMessage={
@@ -225,7 +244,7 @@ const EResources = ({
                     sortOrder={sortOrder.replace(/^-/, '').replace(/,.*/, '')}
                     totalCount={count}
                     virtualize
-                    visibleColumns={['name', 'type', 'isbn', 'eissn', 'pissn']}
+                    visibleColumns={visibleColumns}
                   />
                 </Pane>
               </Paneset>
@@ -242,6 +261,7 @@ EResources.propTypes = {
   data: PropTypes.shape({
     eresources: PropTypes.arrayOf(PropTypes.object).isRequired,
   }),
+  iconKey: PropTypes.string,
   initialFilterState: PropTypes.object,
   initialSearchState: PropTypes.object,
   initialSortState: PropTypes.object,
@@ -258,7 +278,8 @@ EResources.propTypes = {
     loaded: PropTypes.func,
     totalCount: PropTypes.func,
   }),
-  syncToLocationSearch: PropTypes.bool
+  syncToLocationSearch: PropTypes.bool,
+  visibleColumns: PropTypes.arrayOf(PropTypes.string)
 };
 
 export default EResources;

--- a/src/View/View.js
+++ b/src/View/View.js
@@ -17,7 +17,6 @@ import { AppIcon } from '@folio/stripes/core';
 import {
   CollapseFilterPaneButton,
   ExpandFilterPaneButton,
-  SearchAndSortNoResultsMessage,
   SearchAndSortQuery,
 } from '@folio/stripes/smart-components';
 
@@ -30,28 +29,12 @@ import Filters from '../Filters';
 
 import css from './View.css';
 
-const propTypes = {
-  data: PropTypes.shape({
-    eresources: PropTypes.arrayOf(PropTypes.object).isRequired,
-  }),
-  initialFilterState: PropTypes.object,
-  initialSearchState: PropTypes.object,
-  initialSortState: PropTypes.object,
-  onNeedMoreData: PropTypes.func.isRequired,
-  onSelectRow: PropTypes.func.isRequired,
-  queryGetter: PropTypes.func.isRequired,
-  querySetter: PropTypes.func.isRequired,
-  selectedRecordId: PropTypes.string,
-  showPackages: PropTypes.bool,
-  showTitles: PropTypes.bool,
-  sortableColumns: PropTypes.arrayOf(PropTypes.string),
-  source: PropTypes.shape({
-    loaded: PropTypes.func,
-    totalCount: PropTypes.func,
-  }),
-  syncToLocationSearch: PropTypes.bool
-};
-
+/*
+ * Bear in mind that we have split the plugin into 3,
+ * but from the View down all options are managed by
+ * the same components, so need to cater for Packages AND Titles
+ * (and all combinations thereof)
+ */
 const EResources = ({
   data = {},
   initialFilterState = {},
@@ -220,16 +203,7 @@ const EResources = ({
                     }}
                     id="list-eresources"
                     isEmptyMessage={
-                      source || (!showPackages && !showTitles) ? (
-                        <div data-test-eresources-no-results-message>
-                          <SearchAndSortNoResultsMessage
-                            filterPaneIsVisible
-                            searchTerm={query.query ?? ''}
-                            source={source}
-                            toggleFilterPane={toggleFilterPane}
-                          />
-                        </div>
-                      ) : '...'
+                      source || '...'
                     }
                     isSelected={({ item }) => item.id === selectedRecordId}
                     onHeaderClick={onSort}
@@ -253,6 +227,26 @@ const EResources = ({
   );
 };
 
-EResources.propTypes = propTypes;
+EResources.propTypes = {
+  data: PropTypes.shape({
+    eresources: PropTypes.arrayOf(PropTypes.object).isRequired,
+  }),
+  initialFilterState: PropTypes.object,
+  initialSearchState: PropTypes.object,
+  initialSortState: PropTypes.object,
+  onNeedMoreData: PropTypes.func.isRequired,
+  onSelectRow: PropTypes.func.isRequired,
+  queryGetter: PropTypes.func.isRequired,
+  querySetter: PropTypes.func.isRequired,
+  selectedRecordId: PropTypes.string,
+  showPackages: PropTypes.bool,
+  showTitles: PropTypes.bool,
+  sortableColumns: PropTypes.arrayOf(PropTypes.string),
+  source: PropTypes.shape({
+    loaded: PropTypes.func,
+    totalCount: PropTypes.func,
+  }),
+  syncToLocationSearch: PropTypes.bool
+};
 
 export default EResources;

--- a/src/View/View.js
+++ b/src/View/View.js
@@ -17,6 +17,7 @@ import { AppIcon } from '@folio/stripes/core';
 import {
   CollapseFilterPaneButton,
   ExpandFilterPaneButton,
+  SearchAndSortNoResultsMessage,
   SearchAndSortQuery,
 } from '@folio/stripes/smart-components';
 
@@ -203,7 +204,16 @@ const EResources = ({
                     }}
                     id="list-eresources"
                     isEmptyMessage={
-                      source || '...'
+                      source ? (
+                        <div data-test-eresources-no-results-message>
+                          <SearchAndSortNoResultsMessage
+                            filterPaneIsVisible
+                            searchTerm={query.query ?? ''}
+                            source={source}
+                            toggleFilterPane={toggleFilterPane}
+                          />
+                        </div>
+                      ) : '...'
                     }
                     isSelected={({ item }) => item.id === selectedRecordId}
                     onHeaderClick={onSort}

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,6 +3,8 @@ export const FETCH_INCREMENT = 25;
 export const KBS_ENDPOINT = 'erm/kbs';
 export const REFDATA_ENDPOINT = 'erm/refdata';
 export const ERESOURCES_ELECTRONIC_ENDPOINT = 'erm/resource/electronic';
+export const PACKAGES_ENDPOINT = 'erm/packages';
+export const TITLES_ENDPOINT = 'erm/titles/electronic';
 
 export const [
   CONTENT_TYPE,

--- a/src/constants.js
+++ b/src/constants.js
@@ -15,7 +15,7 @@ export const [
   TYPE
 ] = [
   'AvailabilityConstraint.Body',
-  'ContentType.ContentType',
+  'Pkg.ContentType',
   'Pkg.LifecycleStatus',
   'TitleInstance.PublicationType',
   'Pkg.AvailabilityScope',

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,19 @@
+/* All of the containers will need similar constants, so share from this file */
+export const FETCH_INCREMENT = 25;
+export const KBS_ENDPOINT = 'erm/kbs';
+export const REFDATA_ENDPOINT = 'erm/refdata';
+export const ERESOURCES_ELECTRONIC_ENDPOINT = 'erm/resource/electronic';
+
+export const [
+  CONTENT_TYPE,
+  LIFECYCLE_STATUS,
+  PUB_TYPE,
+  SCOPE,
+  TYPE
+] = [
+  'ContentType.ContentType',
+  'Pkg.LifecycleStatus',
+  'TitleInstance.PublicationType',
+  'Pkg.AvailabilityScope',
+  'TitleInstance.Type',
+];

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,12 +7,14 @@ export const PACKAGES_ENDPOINT = 'erm/packages';
 export const TITLES_ENDPOINT = 'erm/titles/electronic';
 
 export const [
+  AVAILABILITY_CONSTRAINT,
   CONTENT_TYPE,
   LIFECYCLE_STATUS,
   PUB_TYPE,
   SCOPE,
   TYPE
 ] = [
+  'AvailabilityConstraint.Body',
   'ContentType.ContentType',
   'Pkg.LifecycleStatus',
   'TitleInstance.PublicationType',

--- a/translations/ui-plugin-find-eresource/en.json
+++ b/translations/ui-plugin-find-eresource/en.json
@@ -5,6 +5,9 @@
   "selectEresource": "Select e-resource",
 
   "eresources": "E-resources",
+  "packages": "Packages",
+  "titles": "Titles",
+
   "package": "Package",
   "searchInputLabel": "Search e-resources",
   "title": "Title",

--- a/translations/ui-plugin-find-eresource/en.json
+++ b/translations/ui-plugin-find-eresource/en.json
@@ -20,6 +20,11 @@
   "prop.type": "Type",
   "prop.pissn": "ISSN (Print)",
 
+  "prop.status": "Status",
+  "prop.source": "Source",
+  "prop.scope": "Scope",
+  "prop.contentType": "Content type",
+
   "yes": "Yes",
   "no": "No"
 }


### PR DESCRIPTION
refactor to complete several issues:
ERM-2916: Implement new package search in ui-plugin-find-eresource
ERM-2917: Implement new title search in ui-plugin-find-eresource
ERM-2918: Implement 25 results limit in ui-plugin-find-eresource

- Separated Container into JointContainer, PackageContainer and TitleContainer
- Container now siphons off into one of those three subContainers.
- Refactored to move shared code and move certain rendering choices up to the separate containers from the shared View component
- tweaked tests