### PR TITLE
ERM-2916: Implement new package search in ui-plugin-find-eresource

### DIFF
--- a/src/Filters/Filters.js
+++ b/src/Filters/Filters.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
-import { Accordion, AccordionSet, FilterAccordionHeader, Selection } from '@folio/stripes/components';
+import { Accordion, AccordionSet, FilterAccordionHeader } from '@folio/stripes/components';
 import { CheckboxFilter, MultiSelectionFilter } from '@folio/stripes/smart-components';
 
 const FILTERS = [

--- a/src/Filters/Filters.js
+++ b/src/Filters/Filters.js
@@ -107,34 +107,6 @@ const Filters = ({
     );
   };
 
-  const renderRemoteKbFilter = () => {
-    const dataOptions = data.sourceValues.map(remoteKb => ({
-      label: remoteKb.name,
-      value: remoteKb.id,
-    }));
-
-    const remoteKbFilters = activeFilters.remoteKb || [];
-
-    return (
-      <Accordion
-        key="render-remote-kb-filter"
-        displayClearButton={remoteKbFilters.length > 0}
-        header={FilterAccordionHeader}
-        id="filter-accordion-remoteKb"
-        label={<FormattedMessage id="ui-plugin-find-eresource.prop.sourceKb" />}
-        onClearFilter={() => { filterHandlers.clearGroup('remoteKb'); }}
-        separator={false}
-      >
-        <Selection
-          dataOptions={dataOptions}
-          id="remoteKb-filter"
-          onChange={value => filterHandlers.state({ ...activeFilters, remoteKb: [value] })}
-          value={remoteKbFilters[0] || ''}
-        />
-      </Accordion>
-    );
-  };
-
   const renderAvailabilityFilter = () => {
     const availabilityFilters = activeFilters.availability || [];
 
@@ -169,7 +141,6 @@ const Filters = ({
     renderCheckboxFilter('scope'),
     renderAvailabilityFilter(),
     renderCheckboxFilter('contentType'),
-    renderRemoteKbFilter()
   ]);
 
   return (

--- a/src/Filters/Filters.test.js
+++ b/src/Filters/Filters.test.js
@@ -3,7 +3,7 @@ import { waitFor } from '@testing-library/dom';
 
 
 import { renderWithIntl } from '@folio/stripes-erm-testing';
-import { Accordion, Checkbox, Selection, SelectionList as SelectListInteractor } from '@folio/stripes-testing';
+import { Accordion, Checkbox } from '@folio/stripes-testing';
 import { MemoryRouter } from 'react-router-dom';
 
 import { activeFilters, data } from './testResources';

--- a/src/Filters/Filters.test.js
+++ b/src/Filters/Filters.test.js
@@ -89,15 +89,5 @@ describe('Filters', () => {
   test('renders the IsPackage Accordion', async () => {
     await Accordion('Is package').exists();
   });
-
-  test('renders the External data source Accordion', async () => {
-    await Accordion('External data source').exists();
-  });
-
-  it('choosing an external data source option', async () => {
-    await Selection({ id: 'remoteKb-filter' }).exists();
-    await Selection().open();
-    await SelectListInteractor({ optionCount: 1 }).exists();
-  });
 });
 


### PR DESCRIPTION
chore: Removed external data source filter

Removed the deprecated "external data source" filter along with associated tests

[ERM-2916](https://issues.folio.org/browse/ERM-2916)